### PR TITLE
Optional overide for duplicate coremod identification

### DIFF
--- a/src/main/java/com/mitchej123/jarjar/config/CoremodExemptions.java
+++ b/src/main/java/com/mitchej123/jarjar/config/CoremodExemptions.java
@@ -1,0 +1,68 @@
+package com.mitchej123.jarjar.config;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Manages the list of coremod class names that should be exempt from duplicate detection.
+ */
+public class CoremodExemptions {
+    private static final Logger LOGGER = LogManager.getLogger("CoremodExemptions");
+    private static final String CONFIG_PATH = "/META-INF/jarjar_coremod_exemptions.cfg";
+
+    private static Set<String> exemptedCoremods = null;
+
+    /**
+     * Check if a coremod class name is exempt from duplicate detection
+     * @param coremodClassName The fully qualified class name of the coremod
+     * @return true if this coremod should be exempt from duplicate detection
+     */
+    public static boolean isExempt(String coremodClassName) {
+        if (exemptedCoremods == null) {
+            loadExemptions();
+        }
+        return exemptedCoremods.contains(coremodClassName);
+    }
+
+    /**
+     * Load the exemption list from the configuration file
+     */
+    private static void loadExemptions() {
+        exemptedCoremods = new HashSet<>();
+
+        try (InputStream is = CoremodExemptions.class.getResourceAsStream(CONFIG_PATH)) {
+            if (is == null) {
+                LOGGER.warn("Could not find coremod exemptions config file: {}", CONFIG_PATH);
+                return;
+            }
+
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
+                String line;
+
+                while ((line = reader.readLine()) != null) {
+                    line = line.trim();
+
+                    // Skip empty lines and comments
+                    if (line.isEmpty() || line.startsWith("#")) {
+                        continue;
+                    }
+
+                    exemptedCoremods.add(line);
+                    LOGGER.debug("Added coremod exemption: {}", line);
+                }
+
+                LOGGER.info("Loaded {} coremod exemptions from {}", exemptedCoremods.size(), CONFIG_PATH);
+            }
+        } catch (IOException e) {
+            LOGGER.error("Failed to load coremod exemptions from {}", CONFIG_PATH, e);
+        }
+    }
+
+}

--- a/src/main/java/com/mitchej123/jarjar/discovery/ModCandidateV2Sorter.java
+++ b/src/main/java/com/mitchej123/jarjar/discovery/ModCandidateV2Sorter.java
@@ -1,5 +1,7 @@
 package com.mitchej123.jarjar.discovery;
 
+import com.mitchej123.jarjar.config.CoremodExemptions;
+import com.mitchej123.jarjar.fml.common.discovery.ModCandidateV2;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -53,6 +55,26 @@ public class ModCandidateV2Sorter<T extends SortableCandidate> {
             if (equalIdCandidates.size() < 2) {
                 continue;
             }
+
+            // Check if this is a coremod that should be exempt from duplicate detection
+            boolean isExemptCoremod = false;
+            // We only need to check one at this point since they're all the same
+            if (equalIdCandidates.get(0) instanceof ModCandidateV2 firstCandidate) {
+                if (firstCandidate.hasCoreMod()) {
+                    String coremodClassName = firstCandidate.getCoreMod();
+                    if (CoremodExemptions.isExempt(coremodClassName)) {
+                        isExemptCoremod = true;
+                        LOGGER.info("Skipping duplicate detection for exempt coremod: {} (found in {} mods)",
+                                   coremodClassName, equalIdCandidates.size());
+                    }
+                }
+            }
+
+            if (isExemptCoremod) {
+                // Skip duplicate detection for exempt coremods
+                continue;
+            }
+
             T newest = null;
             for (final T it : equalIdCandidates) {
                 if (disabled.contains(it)) {

--- a/src/main/resources/META-INF/jarjar_coremod_exemptions.cfg
+++ b/src/main/resources/META-INF/jarjar_coremod_exemptions.cfg
@@ -1,0 +1,13 @@
+# JarJar Coremod Duplicate Detection Exemptions
+#
+# This file contains a list of coremod class names that should be exempt from
+# duplicate detection.
+#
+# Format: One coremod class name per line
+# Lines starting with # are comments and are ignored
+# Empty lines are ignored
+#
+# Example cases:
+# - Thaumcraft's DepLoader vs BaublesExpanded's modified DepLoader
+
+thaumcraft.codechicken.core.launch.DepLoader


### PR DESCRIPTION
There's no obvious easy way to otherwise identify these... so allow for a config based override. 