### PR TITLE
Sort mod candidates case insensitively.

### DIFF
--- a/src/main/java/com/mitchej123/jarjar/fml/relauncher/CoreModManagerV2.java
+++ b/src/main/java/com/mitchej123/jarjar/fml/relauncher/CoreModManagerV2.java
@@ -74,7 +74,7 @@ public final class CoreModManagerV2 extends CoreModManager {
 
     public static final Comparator<ModCandidateV2> COREMOD_COMPARATOR = Comparator.nullsFirst(
         Comparator.comparing(ModCandidateV2::getSortOrder)
-            .thenComparing(ModCandidateV2::getFilename)
+            .thenComparing(ModCandidateV2::getFilename, String.CASE_INSENSITIVE_ORDER)
             .thenComparing(ModCandidateV2::getVersion)
             .thenComparing(ModCandidateV2::getNestLevel));
 


### PR DESCRIPTION
Prevents hard to diagnose issues when Hodgepodge (via daily updater from Maven) is loaded vs hodgepodge (from daily jar).  Keeps mods in the same sort order regardless of capitalization.