### PR TITLE
Include Compile time annotations in ASMDataTable

### DIFF
--- a/src/main/java/com/mitchej123/jarjar/fml/common/discovery/asm/ASMModParserV2.java
+++ b/src/main/java/com/mitchej123/jarjar/fml/common/discovery/asm/ASMModParserV2.java
@@ -38,7 +38,7 @@ import java.util.Set;
 
 public class ASMModParserV2 extends ASMModParser {
 
-    private static final ClassConstantPoolParser PRESCAN = new ClassConstantPoolParser("RuntimeVisibleAnnotations", "RuntimeVisibleParameterAnnotations");
+    private static final ClassConstantPoolParser PRESCAN = new ClassConstantPoolParser("RuntimeVisibleAnnotations", "RuntimeInvisibleAnnotations");
     private static final String DUMMY_MARKER_INTERNAL_NAME = "$JarJarDummy";
     private static final byte[] DUMMY_CLASS_BYTES = buildDummyClassBytes();
 


### PR DESCRIPTION
Include Compile time annotations in ASMDataTable 

* Matches FML behavior.  Params aren't actually read so drop those.